### PR TITLE
Automatically select the first topic

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,8 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="DuplicatedCode" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <GlobalSettings restrictedDuplicateScope="SAME_FILE" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/nodes/lynx-in.html
+++ b/nodes/lynx-in.html
@@ -57,6 +57,7 @@
             }
 
             let installationSelected = () => {
+                node.function_id = 0;
                 installations.map(installation => {
                     if (selectedInstallation.toString() === installation.id.toString()) {
                         node.installation_id = installation.id;
@@ -92,10 +93,15 @@
                         let inputType = $("#node-input-type");
                         inputType.empty();
 
+                        let selectedFirst = false;
                         for (let key in fun.meta) {
                             if (fun.meta.hasOwnProperty(key) && key.startsWith("topic_")) {
                                 let topicButton = getTopicButton(key, fun.meta[key]);
                                 inputType.append(topicButton);
+                                if (!selectedFirst) {
+                                    topicButton.click();
+                                    selectedFirst = true;
+                                }
                             }
                         }
                     }

--- a/nodes/lynx-out.html
+++ b/nodes/lynx-out.html
@@ -57,6 +57,7 @@
             }
 
             let installationSelected = () => {
+                node.function_id = 0;
                 installations.map(installation => {
                     if (selectedInstallation.toString() === installation.id.toString()) {
                         node.installation_id = installation.id;
@@ -92,10 +93,15 @@
                         let inputType = $("#node-input-type");
                         inputType.empty();
 
+                        let selectedFirst = false;
                         for (let key in fun.meta) {
                             if (fun.meta.hasOwnProperty(key) && key.startsWith("topic_")) {
                                 let topicButton = getTopicButton(key, fun.meta[key]);
                                 inputType.append(topicButton);
+                                if (!selectedFirst) {
+                                    topicButton.click();
+                                    selectedFirst = true;
+                                }
                             }
                         }
                     }

--- a/nodes/lynx-server.js
+++ b/nodes/lynx-server.js
@@ -8,7 +8,7 @@ module.exports = function (RED) {
             return true;
         }
 
-        var re = new RegExp("^" + sub.replace(/([\[\]\?\(\)\\\\$\^\*\.|])/g, "\\$1").replace(/\+/g, "[^/]+").replace(/\/#$/, "(\/.*)?") + "$");
+        const re = new RegExp("^" + sub.replace(/([\[\]\?\(\)\\\\$\^\*\.|])/g, "\\$1").replace(/\+/g, "[^/]+").replace(/\/#$/, "(\/.*)?") + "$");
         return re.test(topic);
     }
 
@@ -40,7 +40,7 @@ module.exports = function (RED) {
         this.options.clean = true;
 
         // Defined function for other nodes to use
-        var node = this;
+        let node = this;
         this.users = {};
 
         this.register = (lynxNode) => {
@@ -76,9 +76,8 @@ module.exports = function (RED) {
                     node.client.on('connect', () => {
                         node.connecting = false;
                         node.connected = true;
-                        // Logging?
                         node.log(RED._("lynx.state.connected", {broker: node.options.clientID + "@" + node.broker}));
-                        for (var id in node.users) {
+                        for (let id in node.users) {
                             if (node.users.hasOwnProperty(id)) {
                                 node.users[id].status({
                                     fill: "green",
@@ -88,17 +87,17 @@ module.exports = function (RED) {
                             }
                         }
                         node.client.removeAllListeners('message');
-                        for (var s in node.subscriptions) {
+                        for (let s in node.subscriptions) {
                             if (node.subscriptions.hasOwnProperty(s)) {
-                                var topic = s;
-                                var qos = 0;
+                                let topic = s;
+                                let qos = 0;
 
                                 for (var r in node.subscriptions[s]) {
                                     if (node.subscriptions[s].hasOwnProperty(r)) {
                                         node.client.on('message', node.subscriptions[s][r].handler);
                                     }
                                 }
-                                var options = {qos: 0};
+                                let options = {qos: 0};
                                 node.client.subscribe(topic, options);
                             }
                         }
@@ -146,7 +145,7 @@ module.exports = function (RED) {
         this.subscribe = (topic, qos, callback, ref) => {
             ref = ref || 0;
             node.subscriptions[topic] = node.subscriptions[topic] || {};
-            var sub = {
+            let sub = {
                 topic: topic,
                 qos: qos,
                 handler: (mTopic, mPayload, mPacket) => {
@@ -155,11 +154,11 @@ module.exports = function (RED) {
                     }
                 },
                 ref: ref
-            }
+            };
             node.subscriptions[topic][ref] = sub;
             if (node.connected) {
                 node.client.on('message', sub.handler);
-                var options = {};
+                let options = {};
                 options.qos = qos;
                 node.client.subscribe(topic, options);
             }
@@ -167,7 +166,7 @@ module.exports = function (RED) {
 
         this.unsubscribe = (topic, ref, removed) => {
             ref = ref || 0;
-            var sub = node.subscriptions[topic];
+            let sub = node.subscriptions[topic];
             if (sub) {
                 if (sub[ref]) {
                     node.client.removeListener('message', sub[ref].handler);
@@ -196,7 +195,7 @@ module.exports = function (RED) {
                     }
                 }
 
-                var options = {
+                let options = {
                     qos: msg.qos || 0,
                     retain: msg.retain || false
                 };
@@ -225,8 +224,8 @@ module.exports = function (RED) {
     RED.nodes.registerType('lynx-server', LynxServerNode);
 
     RED.httpAdmin.get("/lynx/installations", RED.auth.needsPermission('lynx_server.read'), function (req, res) {
-        var baseURL = req.query.url;
-        var apiKey = req.query.apiKey;
+        let baseURL = req.query.url;
+        let apiKey = req.query.apiKey;
 
         const cli = new lynx.LynxClient(baseURL, apiKey);
         cli.getInstallations()
@@ -239,9 +238,9 @@ module.exports = function (RED) {
     });
 
     RED.httpAdmin.get("/lynx/functions/:installation_id", RED.auth.needsPermission('lynx_server.read'), function (req, res) {
-        var baseURL = req.query.url;
-		var  apiKey = req.query.apiKey;
-        var installationId = req.params.installation_id;
+        let baseURL = req.query.url;
+        let apiKey = req.query.apiKey;
+        let installationId = req.params.installation_id;
 
         const cli = new lynx.LynxClient(baseURL, apiKey);
         cli.getFunctions(installationId)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@iotopen/node-red-contrib-lynx",
-  "version": "1.0.2",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.1.1",
   "description": "NodeRED integration for IoT Open Lynx",
   "scripts": {
-    "prepublish": "babel nodes/ --out-dir lib && cp nodes/*.html lib/"
+    "prepublish": "babel nodes/ --out-dir lib && cp nodes/*.html lib/",
+    "debug": "babel nodes/ --out-dir lib && cp nodes/*.html lib/ && node-red"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #2 

Make no function selected when switching installation.
Installation is selected, selecting the first function.
Function is selected, then select the first topic in the button-group.